### PR TITLE
grpc: expose the healthcheck type in GRPCConnection

### DIFF
--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -186,16 +186,16 @@ impl crate::HealthChecker<BoxBody> for GRPCHealthChecker {
 /// [`tower_service::Service`] with [`BoxBody`] as the HTTP request body
 /// as required for wrapping a [`tonic`] gRPC client arount it.
 #[cfg(feature = "metrics")]
-pub type GRPCChannel<A, C> = crate::channel::Channel<
+pub type GRPCChannel<A, C, HC = GRPCHealthChecker> = crate::channel::Channel<
     tonic_prometheus_layer::MetricsChannel<
-        crate::channel::PoolService<A, BoxBody, C, GRPCHealthChecker>,
+        crate::channel::PoolService<A, BoxBody, C, HC>,
     >,
     BoxBody,
 >;
 
 #[cfg(not(feature = "metrics"))]
-pub type GRPCChannel<A, C> =
-    crate::channel::Channel<crate::channel::PoolService<A, BoxBody, C, GRPCHealthChecker>, BoxBody>;
+pub type GRPCChannel<A, C, HC = GRPCHealthChecker> =
+    crate::channel::Channel<crate::channel::PoolService<A, BoxBody, C, HC>, BoxBody>;
 
 /// Create a new always-ready load-balanced gRPC client channel.
 ///


### PR DESCRIPTION
All traits to write a custom health checker are public in the crate, yet no type alias allow to override it. Without this default generic type, it would require rewriting the whole type alias which is pretty deep.

As a matter of fact, half of the types that actually make up this type are private to the crate, making it _impossible_ to express the full type. See https://docs.rs/warm_channels/latest/warm_channels/grpc/type.GRPCChannel.html that will show such types as plain text without hyperlinks (`ShimmedService`, `ShimmedStream`, `PoolMemberKey`, `HTTP2Connection`).